### PR TITLE
Detect lack of tests

### DIFF
--- a/bin/test_runner.gd
+++ b/bin/test_runner.gd
@@ -149,16 +149,25 @@ func run_tests() -> void:
 	`results.json` file in the output dir.
 	"""
 	var test_results = test_utils.run_tests(solution_script, test_suite_script)
+	var results = {}
 	
-	var results = {
-		"status": "pass",
-		"tests": test_results,
-	}
-	
-	# If any of the tests failed, change the global status to `fail`
-	for test_result in test_results:
-		if test_result["status"] != "pass":
-			results["status"] = "fail"
-			break
+	# Check if any tests were executed
+	if len(test_results) == 0:
+		results = {
+			"status": "error",
+			"message": "No tests were executed.",
+			"tests": [],
+		}
+	else:
+		results = {
+			"status": "pass",
+			"tests": test_results,
+		}
+		
+		# If any of the tests failed, change the global status to `fail`
+		for test_result in test_results:
+			if test_result["status"] != "pass":
+				results["status"] = "fail"
+				break
 	
 	file_utils.write_results_file(results, output_dir_path)

--- a/tests/example-no-tests/example_no_tests.gd
+++ b/tests/example-no-tests/example_no_tests.gd
@@ -1,0 +1,2 @@
+func add_2_numbers(a, b):
+	return a + b

--- a/tests/example-no-tests/example_no_tests_test.gd
+++ b/tests/example-no-tests/example_no_tests_test.gd
@@ -1,0 +1,6 @@
+func invalid_test_1_and_2_equals_3(solution_script):
+	return [3, solution_script.add_2_numbers(1, 2)]
+
+
+func invalid_test_10_and_20_equals_30(solution_script):
+	return [30, solution_script.add_2_numbers(10, 20)]

--- a/tests/example-no-tests/expected_results.json
+++ b/tests/example-no-tests/expected_results.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "status": "error",
+  "message": "No tests were executed.",
+  "tests": []
+}


### PR DESCRIPTION
Currently, if the test file is invalid (e.g. mixes tab and space indentation), no tests will be executed by the runner. However, the situation is not currently treated as an error, resulting in a green check in GitHub actions. Because of this, after adding each exercise, the logs have to be manually validated to confirm that the corresponding tests were correctly executed.

This PR will make the test suite fail if no tests were executed.