### PR TITLE
Swap actual and expected values in test runner, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ Each test suite consists of a single GDScript file. Its name has to be equal to 
 
 Each test case will be called with a single argument. That argument is the solution script, prepared by the user and loaded by the test runner as a Script object. The test case can call any methods of the solution script, as well as perform any setup steps (if necessary).
 
-Each test case is expected to return an Array of 2 elements. The first is the expected value, the second is the value received from calling a user defined method. The test runner will take care of comparing those values and generating an error message, if necessary.
+Each test case is expected to return an Array of 2 elements. The first is the value received from calling a user defined method, the second is the expected value. The test runner will take care of comparing those values and generating an error message, if necessary.
 
 A full test suite file might look like this:
 
 ```
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]
 ```
 
 ## Run the test runner

--- a/bin/utils/test_utils.gd
+++ b/bin/utils/test_utils.gd
@@ -19,8 +19,8 @@ func run_tests(solution_script: Object, test_suite_script: Object) -> Array:
 	`status` will be set to 'error'. The test will also receive an 'error' status
 	if calling the `test_` method returned null (which indicates execution issues).
 	
-	Otherwise, the `test_` method should return an Array of 2 elements: the expected value,
-	and the actual value. The values will be compared and if they are the same, the test will
+	Otherwise, the `test_` method should return an Array of 2 elements: the actual value,
+	and the expected value. The values will be compared and if they are the same, the test will
 	pass. Otherwise, it will fail, with a relevant message being set by this method.
 	"""
 	var test_results = []
@@ -41,8 +41,8 @@ func run_tests(solution_script: Object, test_suite_script: Object) -> Array:
 					"message": error_message,
 				})
 			else:
-				var expected = output[0]
-				var actual = output[1]
+				var actual = output[0]
+				var expected = output[1]
 				
 				var passed = (
 					typeof(actual) == typeof(expected) and
@@ -54,7 +54,7 @@ func run_tests(solution_script: Object, test_suite_script: Object) -> Array:
 				if error_message.is_empty():
 					status = "pass" if passed else "fail"
 					error_message = null if passed else get_failed_test_message(
-						expected, actual
+						actual, expected
 					)
 				
 				test_results.append({
@@ -66,22 +66,22 @@ func run_tests(solution_script: Object, test_suite_script: Object) -> Array:
 	return test_results
 
 
-func get_failed_test_message(expected, actual) -> String:
+func get_failed_test_message(actual, expected) -> String:
 	"""
 	Generates a message for a failed test. If given values are strings,
 	this method will wrap them in single quotes, to distinguish from
 	other types, like integers (e.g. '3' vs 3).
 	
-	This method should be used if the expected and actual values for a
+	This method should be used if the actual and expected values for a
 	given test are different, or if they have different types.
 	"""
 	var values = []
 	
-	for value in [expected, actual]:
+	for value in [actual, expected]:
 		var formatted_value = str(value)
 		if typeof(value) == TYPE_STRING:
 			formatted_value = "'{0}'".format([formatted_value])
 		values.append(formatted_value)
 	
-	return "Expected output was {0}, actual output was {1}.".format(values)
+	return "Expected output was {1}, actual output was {0}.".format(values)
 

--- a/tests/example-all-fail/example_all_fail_test.gd
+++ b/tests/example-all-fail/example_all_fail_test.gd
@@ -1,14 +1,14 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]
 
 
 func test_add_0_and_3(solution_script):
-	return [3, solution_script.add_2_numbers(0, 3)]
+	return [solution_script.add_2_numbers(0, 3), 3]
 
 
 func test_add_0_and_0(solution_script):
-	return [0, solution_script.add_2_numbers(0, 0)]
+	return [solution_script.add_2_numbers(0, 0), 0]

--- a/tests/example-empty-file/example_empty_file_test.gd
+++ b/tests/example-empty-file/example_empty_file_test.gd
@@ -1,6 +1,6 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]

--- a/tests/example-execution-error/example_execution_error_test.gd
+++ b/tests/example-execution-error/example_execution_error_test.gd
@@ -1,6 +1,6 @@
 func test_1(solution_script):
-	return [1, solution_script.divide(1)]
+	return [solution_script.divide(1), 1]
 
 
 func test_0(solution_script):
-	return [false, solution_script.divide(0)]
+	return [solution_script.divide(0), false]

--- a/tests/example-has-stdout/example_has_stdout_test.gd
+++ b/tests/example-has-stdout/example_has_stdout_test.gd
@@ -1,6 +1,6 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]

--- a/tests/example-helper-methods/example_helper_methods_test.gd
+++ b/tests/example-helper-methods/example_helper_methods_test.gd
@@ -1,6 +1,6 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]

--- a/tests/example-incorrect-number-of-arguments/example_incorrect_number_of_arguments_test.gd
+++ b/tests/example-incorrect-number-of-arguments/example_incorrect_number_of_arguments_test.gd
@@ -1,6 +1,6 @@
 func test_too_few_args(solution_script):
-	return [null, solution_script.add_numbers(1)]
+	return [solution_script.add_numbers(1), null]
 
 
 func test_too_many_args(solution_script):
-	return [null, solution_script.add_numbers(10, 20, 40)]
+	return [solution_script.add_numbers(10, 20, 40), null]

--- a/tests/example-incorrect-return-type/example_incorrect_return_type_test.gd
+++ b/tests/example-incorrect-return-type/example_incorrect_return_type_test.gd
@@ -1,14 +1,14 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]
 
 
 func test_add_0_and_3(solution_script):
-	return [3, solution_script.add_2_numbers(0, 3)]
+	return [solution_script.add_2_numbers(0, 3), 3]
 
 
 func test_add_0_and_0(solution_script):
-	return [0, solution_script.add_2_numbers(0, 0)]
+	return [solution_script.add_2_numbers(0, 0), 0]

--- a/tests/example-invalid-argument-type/example_invalid_argument_type_test.gd
+++ b/tests/example-invalid-argument-type/example_invalid_argument_type_test.gd
@@ -1,10 +1,10 @@
 func test_string_something(solution_script):
-	return [true, solution_script.check_something("something")]
+	return [solution_script.check_something("something"), true]
 
 
 func test_string_nothing(solution_script):
-	return [false, solution_script.check_something("nothing")]
+	return [solution_script.check_something("nothing"), false]
 
 
 func test_integer(solution_script):
-	return [false, solution_script.check_something(10)]
+	return [solution_script.check_something(10), false]

--- a/tests/example-multiple-methods-partial-fail/example_multiple_methods_partial_fail_test.gd
+++ b/tests/example-multiple-methods-partial-fail/example_multiple_methods_partial_fail_test.gd
@@ -1,10 +1,10 @@
 func test_add_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_3(solution_script):
-	return [7, solution_script.add_3_numbers(1, 2, 4)]
+	return [solution_script.add_3_numbers(1, 2, 4), 7]
 
 
 func test_hello(solution_script):
-	return ["Hello!", solution_script.return_hello()]
+	return [solution_script.return_hello(), "Hello!"]

--- a/tests/example-multiple-methods-success/example_multiple_methods_success_test.gd
+++ b/tests/example-multiple-methods-success/example_multiple_methods_success_test.gd
@@ -1,10 +1,10 @@
 func test_add_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_3(solution_script):
-	return [7, solution_script.add_3_numbers(1, 2, 4)]
+	return [solution_script.add_3_numbers(1, 2, 4), 7]
 
 
 func test_hello(solution_script):
-	return ["Hello!", solution_script.return_hello()]
+	return [solution_script.return_hello(), "Hello!"]

--- a/tests/example-no-tests/example_no_tests_test.gd
+++ b/tests/example-no-tests/example_no_tests_test.gd
@@ -1,6 +1,6 @@
 func invalid_test_1_and_2_equals_3(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func invalid_test_10_and_20_equals_30(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]

--- a/tests/example-not-a-callable/example_not_a_callable_test.gd
+++ b/tests/example-not-a-callable/example_not_a_callable_test.gd
@@ -1,2 +1,2 @@
 func test_call_a_method(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]

--- a/tests/example-partial-fail/example_partial_fail_test.gd
+++ b/tests/example-partial-fail/example_partial_fail_test.gd
@@ -1,14 +1,14 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]
 
 
 func test_add_0_and_3(solution_script):
-	return [3, solution_script.add_2_numbers(0, 3)]
+	return [solution_script.add_2_numbers(0, 3), 3]
 
 
 func test_add_0_and_0(solution_script):
-	return [0, solution_script.add_2_numbers(0, 0)]
+	return [solution_script.add_2_numbers(0, 0), 0]

--- a/tests/example-return-correct-value-incorrect-type/example_return_correct_value_incorrect_type_test.gd
+++ b/tests/example-return-correct-value-incorrect-type/example_return_correct_value_incorrect_type_test.gd
@@ -1,2 +1,2 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]

--- a/tests/example-return-falsy/example_return_falsy_test.gd
+++ b/tests/example-return-falsy/example_return_falsy_test.gd
@@ -1,22 +1,22 @@
 func test_zero(solution_script):
-	return [0, solution_script.return_0()]
+	return [solution_script.return_0(), 0]
 
 
 func test_false(solution_script):
-	return [false, solution_script.return_false()]
+	return [solution_script.return_false(), false]
 
 
 func test_empty_array(solution_script):
-	return [[], solution_script.return_empty_array()]
+	return [solution_script.return_empty_array(), []]
 
 
 func test_empty_string(solution_script):
-	return ["", solution_script.return_empty_string()]
+	return [solution_script.return_empty_string(), ""]
 
 
 func test_null(solution_script):
-	return [null, solution_script.return_null()]
+	return [solution_script.return_null(), null]
 
 
 func test_nothing(solution_script):
-	return [null, solution_script.return_nothing()]
+	return [solution_script.return_nothing(), null]

--- a/tests/example-success/example_success_test.gd
+++ b/tests/example-success/example_success_test.gd
@@ -1,6 +1,6 @@
 func test_1_and_2_equals_3(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_10_and_20_equals_30(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]

--- a/tests/example-syntax-error/example_syntax_error_test.gd
+++ b/tests/example-syntax-error/example_syntax_error_test.gd
@@ -1,6 +1,6 @@
 func test_add_1_and_2(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_add_10_and_20(solution_script):
-	return [30, solution_script.add_2_numbers(10, 20)]
+	return [solution_script.add_2_numbers(10, 20), 30]

--- a/tests/example-type-hints/example_type_hints_test.gd
+++ b/tests/example-type-hints/example_type_hints_test.gd
@@ -1,14 +1,14 @@
 func test_return_string_correct(solution_script):
-	return ["Hello!", solution_script.return_string("Hello!")]
+	return [solution_script.return_string("Hello!"), "Hello!"]
 
 
 func test_return_string_incorrect(solution_script):
-	return [1, solution_script.return_string(1)]
+	return [solution_script.return_string(1), 1]
 
 
 func test_accept_int_correct(solution_script):
-	return [1, solution_script.accept_int(1)]
+	return [solution_script.accept_int(1), 1]
 
 
 func test_accept_int_incorrect(solution_script):
-	return ["Hello!", solution_script.accept_int("Hello!")]
+	return [solution_script.accept_int("Hello!"), "Hello!"]

--- a/tests/example-wrong-method-name/example_wrong_method_name_test.gd
+++ b/tests/example-wrong-method-name/example_wrong_method_name_test.gd
@@ -1,6 +1,6 @@
 func test_1_and_2_equals_3(solution_script):
-	return [3, solution_script.add_2_numbers(1, 2)]
+	return [solution_script.add_2_numbers(1, 2), 3]
 
 
 func test_10_and_20_and_40_equals_70(solution_script):
-	return [70, solution_script.add_3_numbers(10, 20, 40)]
+	return [solution_script.add_3_numbers(10, 20, 40), 70]


### PR DESCRIPTION
Currently, most of the tests in GDScript track return `[actual, expected]` instead of `[expected, actual]`, as initially assumed by the test runner. As a result, error messages can be a bit confusing :sweat_smile: 

I decided that it actually makes more sense to settle for `[actual, expected]` and update the tests that use the original version. @glaxxie @BNAndras could you please take a look if I haven't missed anything? :wink: 