### PR TITLE
Move to /opt/exercism/gdscript/test-runner/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN wget https://github.com/godotengine/godot/releases/download/4.4.1-stable/God
     mv Godot_v4.4.1-stable_linux.x86_64 /usr/bin/godot && \
     rm Godot_v4.4.1-stable_linux.x86_64.zip
 
-WORKDIR /opt/test-runner
+WORKDIR /opt/exercism/gdscript/test-runner
 COPY . .
-ENTRYPOINT ["/opt/test-runner/bin/run.sh"]
+ENTRYPOINT ["/opt/exercism/gdscript/test-runner/bin/run.sh"]

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -23,9 +23,9 @@ docker run \
     --rm \
     --network none \
     --read-only \
-    --mount type=bind,src="${PWD}/tests",dst=/opt/test-runner/tests \
+    --mount type=bind,src="${PWD}/tests",dst=/opt/exercism/gdscript/test-runner/tests \
     --mount type=tmpfs,dst=/tmp \
-    --volume "${PWD}/bin/run-tests.sh:/opt/test-runner/bin/run-tests.sh" \
-    --workdir /opt/test-runner \
-    --entrypoint /opt/test-runner/bin/run-tests.sh \
+    --volume "${PWD}/bin/run-tests.sh:/opt/exercism/gdscript/test-runner/bin/run-tests.sh" \
+    --workdir /opt/exercism/gdscript/test-runner \
+    --entrypoint /opt/exercism/gdscript/test-runner/bin/run-tests.sh \
     exercism/test-runner


### PR DESCRIPTION
Keeps Docker vs. native more consistent while avoiding collisions on native systems, per http://forum.exercism.org/t/create-new-track-for-gdscript/3955/175