### PR TITLE
Remove jq from Dockerfile since its only use was removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 RUN apt-get update && \
-    apt-get install -y jq coreutils wget zip libfontconfig1 && \
+    apt-get install -y coreutils wget zip libfontconfig1 && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Cf. https://github.com/exercism/gdscript-test-runner/pull/2/files#diff-00a80c5821edea2ebf676056aa4c9a24e57379ef52cefecb2ccffaaf4cc362c9L43