### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7
 
 RUN apt-get update && \
     apt-get install -y coreutils wget zip libfontconfig1 && \


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.